### PR TITLE
Bash scripts for building toolchain and cross-compile client binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+language: go 
+
+sudo: false
+
+os:
+    -linux
+
+go:
+    - 1.10.x
+
+env:
+  global:
+    - TOOLCHAIN=arm-cortex_a8-linux-gnueabihf
+    - TOOLCHAIN_PATH=$HOME/x-tools
+    - OS=linux
+    - ARCH=arm7
+    - MENDER=mender-$OS-$ARCH
+
+before_install:
+    - sudo apt-get install -y gperf texinfo bison flex help2man ncurses-dev
+    - go get github.com/mendersoftware/mender
+
+install: true
+
+before_script:
+
+script:
+    - ./client-cross-compilation-tool.sh build -p Cortex-A8
+    - if [[ ! -d $TOOLCHAIN_PATH/$TOOLCHAIN ]]; then 
+        echo -e "\nError: tool-chain build failure."
+        exit 1
+      fi
+    - ./go-executable-build.sh -n github.com/mendersoftware/mender -p Cortex-A8
+    - if [[ ! -f $MENDER ]]; then
+        echo - "\nError: mender client binary not found."
+        exit 1
+      fi
+    - cpu=($($TOOLCHAIN_PATH/$TOOLCHAIN/bin/$TOOLCHAIN-readelf $MENDER -a | grep 'Tag_CPU_name' | tr -s ' ' | cut -d' ' -f3))
+      [[ $cpu == '"Cortex-A8"' ]] && { echo "Success."; exit 0; } || { echo "Failure. Binary file attributes mismatch."; exit 1 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
-language: go 
+language: go
 
 sudo: false
 
 os:
-    -linux
+    - linux
 
 go:
     - 1.10.x
@@ -25,15 +25,37 @@ install: true
 before_script:
 
 script:
-    - ./client-cross-compilation-tool.sh build -p Cortex-A8
-    - if [[ ! -d $TOOLCHAIN_PATH/$TOOLCHAIN ]]; then 
-        echo -e "\nError: tool-chain build failure."
-        exit 1
-      fi
-    - ./go-executable-build.sh -n github.com/mendersoftware/mender -p Cortex-A8
-    - if [[ ! -f $MENDER ]]; then
-        echo - "\nError: mender client binary not found."
-        exit 1
-      fi
-    - cpu=($($TOOLCHAIN_PATH/$TOOLCHAIN/bin/$TOOLCHAIN-readelf $MENDER -a | grep 'Tag_CPU_name' | tr -s ' ' | cut -d' ' -f3))
-      [[ $cpu == '"Cortex-A8"' ]] && { echo "Success."; exit 0; } || { echo "Failure. Binary file attributes mismatch."; exit 1 }
+  - |
+    ./client-cross-compilation-tool.sh build -p Cortex-A8
+    ret=$?
+    if [[ $ret -ne 0 ]]; then
+      echo -e "\nError: toolchain build failure."
+      exit $ret
+    fi
+  - |
+    if [[ ! -d "${TOOLCHAIN_PATH}/${TOOLCHAIN}" ]]; then
+      echo -e "\nError: invalid toolchain path."
+      exit 1
+    fi
+  - |
+    PATH="${PATH}:${TOOLCHAIN_PATH}/${TOOLCHAIN}/bin"
+    ./go-executable-build.sh -n github.com/mendersoftware/mender -p Cortex-A8
+    ret=$?
+    if [[ $ret -ne 0 ]]; then
+      echo -e "\nError: Mender client binary build failure."
+      exit $ret
+    fi
+  - |
+    if [[ ! -f $MENDER ]]; then
+      echo - "\nError: mender client binary not found."
+      exit 1
+    fi
+  - |
+    cpu=($($TOOLCHAIN_PATH/$TOOLCHAIN/bin/$TOOLCHAIN-readelf $MENDER -a | grep 'Tag_CPU_name' | tr -s ' ' | cut -d' ' -f3))
+    if [[ $cpu == '"Cortex-A8"' ]]; then
+      echo "Success."
+      exit 0
+    else
+      echo "Failure. Binary file attributes mismatch."
+      exit 1
+    fi

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Pre-compiled tool-chain (e.g. linaro, bootlin) can be used for building Mender c
 Use *client-cross-compilation-tool --help* command to find out supported CPUs and available options.
 
 **crosstool-ng** dependencies:
-* bison, flex, help2man, ncurses-dev
+* gperf, texinfo, bison, flex, help2man, ncurses-dev
 
 Default target directory for *crosstool-ng* based toolchain is *~/x-tools*.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,75 @@
+[![Build Status](https://travis-ci.org/mendersoftware/mender-crossbuild.svg?branch=master)](https://travis-ci.org/mendersoftware/mender-crossbuild)
+[![codecov](https://codecov.io/gh/mendersoftware/mender-crossbuild/branch/master/graph/badge.svg)](https://codecov.io/gh/mendersoftware/mender-crossbuild)
+
+Mender: over-the-air updater for embedded Linux devices
+==============================================
+
+Mender is an open source over-the-air (OTA) software updater for embedded Linux
+devices. Mender comprises a client running at the embedded device, as well as
+a server that manages deployments across many devices.
+
+Embedded product teams often end up creating homegrown updaters at the last
+minute due to the need to fix bugs in field-deployed devices. However, the most
+important requirement for an embedded update process is *robustness*, for example
+loss of power at any time should not brick a device. This creates a challenge
+given the time constraints to develop and maintain a homegrown updater.
+
+Mender aims to address this challenge with a *robust* and *easy to use* updater
+for embedded Linux devices, which is open source and available to anyone.
+
+Robustness is ensured with *atomic* image-based deployments using a dual A/B
+rootfs partition layout. This makes it always possible to roll back to a working state, even
+when losing power at any time during the update process.
+
+Ease of use is addressed with an intuitive UI, [comprehensive documentation](https://docs.mender.io/), a
+[meta layer for the Yocto Project](https://github.com/mendersoftware/meta-mender) for *easy integration into existing environments*,
+and high quality software (see the test coverage badge).
+
+This repository contains the Mender client updater, which can be run in standalone mode
+(manually triggered through its command line interface) or managed mode (connected to the Mender server).
+
+Mender not only provides the client-side updater, but also the backend and UI
+for managing deployments as open source. The Mender server is
+designed as a microservices architecture and comprises several repositories.
+
+
+## Cross-compiling the Mender client
+
+The Mender client binary can be cross-compiled for a given device architecture. Note that in this case you will also need to do bootloader integration and partition setup to integrate it to a device. See [the device integration documentation](https://docs.mender.io/devices?target=_blank) for more information.
+
+Pre-compiled tool-chain (e.g. linaro, bootlin) can be used for building Mender client binary as well as self-compiled customized tool-chain built with **crosstool-ng**.
+
+Use *client-cross-compilation-tool --help* command to find out supported CPUs and available options.
+
+**crosstool-ng** dependencies:
+* bison, flex, help2man, ncurses-dev
+
+Default target directory for *crosstool-ng* based toolchain is *~/x-tools*.
+
+To work with *go-executable-build* script first specifiy the location of your workspace with the GOPATH environment variable. Copy script to *$GOPATH/src* directory. Use *go get github.com/mendersoftware/mender* to download the Mender client code.
+
+Having tool-chain ready (either pre-compiled or customized) one can compile Mender client binary. Use *go-executable-build* script to perform that job. Building binaries for more that one architecture at once is supported. To distinguish binaries their names follow the scheme: mender-_OS_-_ARCH_.
+
+
+## Contributing
+
+We welcome and ask for your contribution. If you would like to contribute to Mender, please read our guide on how to best get started [contributing code or documentation](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md).
+
+## License
+
+Mender is licensed under the Apache License, Version 2.0. See [LICENSE](https://github.com/mendersoftware/mender-crossbuild/blob/master/LICENSE) for the full license text.
+
+## Security disclosure
+
+We take security very seriously. If you come across any issue regarding
+security, please disclose the information by sending an email to
+[security@mender.io](security@mender.io). Please do not create a new public
+issue. We thank you in advance for your cooperation.
+
+## Connect with us
+
+* Join our [Google group](https://groups.google.com/a/lists.mender.io/forum/#!forum/mender)
+* Follow us on [Twitter](https://twitter.com/mender_io?target=_blank). Please
+  feel free to tweet us questions.
+* Fork us on [Github](https://github.com/mendersoftware)
+* Email us at [contact@mender.io](mailto:contact@mender.io)

--- a/client-cross-compilation-tool.sh
+++ b/client-cross-compilation-tool.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+
+# Specify crosstools-ng version and some build directories.
+CROSSTOOL_VERSION=1.23.0
+BASEDIR=~/client-toolchain
+CROSS_TOOL_HOME=$BASEDIR/crosstool/source/
+CROSS_TOOL_PREFIX=$BASEDIR/crosstool/bin/
+TOOLCHAIN_HOME=$BASEDIR/toolchain/
+
+show_help() {
+cat << EOF
+Usage: $0 {build|clean} [-p processor] [-t crosstool|toolchain]
+
+      -p, --processor        specify processor to build the compiler for
+
+      -t, --type             clean build/configuration files or remove the directory
+                             holding files either for crosstool-ng or toolchain
+
+      Supported processors are: Cortex-A8 / Cortex-A53.
+EOF
+}
+
+do_clean() {
+  PATH="${PATH}:$CROSS_TOOL_PREFIX/bin"
+
+  if [ "$TYPE" == "crosstool" ]; then
+    if [ -d "$CROSS_TOOL_HOME" ]; then
+      rm -rf $CROSS_TOOL_HOME
+    fi
+  elif [ "$TYPE" == "toolchain" ]; then
+    command -v ct-ng >/dev/null 2>&1 || { echo >&2 "ct-ng not found. Aborting."; exit 1; }
+    if [ -d "$TOOLCHAIN_HOME" ]; then
+      cd $TOOLCHAIN_HOME
+      ct-ng distclean
+    fi
+  else
+    echo "Error: unknown clean type argument: $TYPE"
+    exit 1
+  fi
+
+  if [ $? -eq 0 ]; then
+    echo "$TYPE build/configuration files removed."
+  else
+    echo "Error: something went wrong."
+  fi
+}
+
+do_build() {
+  if [ "$PROCESSOR" != "Cortex-A8" ] && [ "$PROCESSOR" != "Cortex-A53" ]
+  then
+    echo "Processor type must be Cortex-A8 or Cortex-A53."
+    exit 1
+  fi
+
+  # Make the directories.
+  mkdir -p $CROSS_TOOL_HOME
+  mkdir -p $CROSS_TOOL_PREFIX
+  mkdir -p $TOOLCHAIN_HOME
+
+  # Download, verify and build crosstools-ng.
+  cd $CROSS_TOOL_HOME
+
+  wget -nc http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-$CROSSTOOL_VERSION.tar.bz2
+  tar xjf crosstool-ng-$CROSSTOOL_VERSION.tar.bz2
+
+  gpg --recv-keys 35B871D1 11D618A4
+  wget -nc http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-$CROSSTOOL_VERSION.tar.bz2.sig
+  gpg --verify crosstool-ng-$CROSSTOOL_VERSION.tar.bz2.sig
+
+  if [ $? -ne 0 ]
+  then
+    echo "Can't verify signature."
+    exit 1
+  fi
+
+  # Remove keys - no longer needed.
+  gpg --batch --yes --delete-keys 35B871D1 11D618A4
+
+  if [[ ! -f $CROSS_TOOL_PREFIX/bin/ct-ng ]]; then
+    cd crosstool-ng-$CROSSTOOL_VERSION
+    ./configure --prefix=$CROSS_TOOL_PREFIX
+    make
+    make install
+  fi
+
+  PATH="${PATH}:$CROSS_TOOL_PREFIX/bin"
+
+  # Configure toolchain for desired processor.
+  # Supported are: Cortex-A8, Cortex-A53.
+
+  cd $TOOLCHAIN_HOME
+
+  # Check if there is any valid configuration set already.
+  if [[ ! -f $TOOLCHAIN_HOME/.config ]]; then
+    if [ "$PROCESSOR" == "Cortex-A8" ]; then
+      ct-ng arm-cortex_a8-linux-gnueabi
+      sed -i '/# CT_ARCH_FLOAT_HW/c\CT_ARCH_FLOAT_HW=y' .config
+      sed -i '/CT_ARCH_FLOAT_SW=y/c\# CT_ARCH_FLOAT_SW is not set' .config
+      sed -i '/CT_ARCH_FLOAT="soft"/c\CT_ARCH_FLOAT="hard"' .config
+      sed -i '/CT_ARCH_ARM_EABI=y/a CT_ARCH_ARM_TUPLE_USE_EABIHF=y' .config
+      sed -i '/CT_ARCH_FPU/c\CT_ARCH_FPU="neon"' .config
+      TARGET=arm-cortex_a8-linux-gnueabihf
+    elif [ "$PROCESSOR" == "Cortex-A53" ]; then
+      ct-ng armv8-rpi3-linux-gnueabihf
+      TARGET=armv8-rpi3-linux-gnueabihf
+    else
+      exit 1
+    fi
+    # Additional options must be set to store buidling steps.
+    sed -i '/# CT_DEBUG_CT/c\CT_DEBUG_CT=y' .config
+    sed -i '/CT_DEBUG_CT=y/a CT_DEBUG_CT_SAVE_STEPS=y' .config
+    # To save device space archive steps.
+    sed -i '/CT_DEBUG_CT_SAVE_STEPS=y/a CT_DEBUG_CT_SAVE_STEPS_GZIP=y' .config
+  fi
+
+  # Take a taget name from the build.log if any.
+  if [[ -f $TOOLCHAIN_HOME/build.log ]]; then
+    line=$(grep -rn "target =" build.log)
+    TARGET=$(echo -e $line | awk '{print $NF}')
+    echo "TARGET: $TARGET"
+  fi
+
+  CORES=$(grep -c ^processor /proc/cpuinfo 2>/dev/null)
+
+  # Download all necessary tools and make a break.
+  ct-ng build.$CORES STOP=companion_tools_for_build
+
+  # Download and apply patch for GCC 6.3.
+  wget -c https://raw.githubusercontent.com/coreboot/coreboot/master/util/crossgcc/patches/gcc-6.3.0_pointer_integer.patch
+  patch -p1 .build/src/gcc-6.3.0/gcc/ubsan.c gcc-6.3.0_pointer_integer.patch
+
+  # Restart build process.
+  ct-ng build.$CORES 
+
+  if [[ $TARGET ]]; then
+    PATH=$PATH:~/x-tools/$TARGET/bin
+    $TARGET-gcc -v
+  fi
+}
+
+PARAMS=""
+
+while (( "$#" )); do
+  case "$1" in
+    -p | --processor)
+      PROCESSOR=$2
+      shift 2
+      ;;
+    -t | --type)
+      TYPE=$2
+      shift 2
+      ;;
+    -h | --help)
+      show_help
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "Error: unsupported option $1" >&2
+      exit 1
+      ;;
+    *)
+      PARAMS="$PARAMS $1"
+      shift
+      ;;
+  esac
+done
+
+eval set -- "$PARAMS"
+
+case "$1" in
+  build)
+    do_build
+    ;;
+  clean)
+    do_clean
+    ;;
+  *)
+    show_help
+    ;;
+esac

--- a/go-executable-build.sh
+++ b/go-executable-build.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+TOOLCHAIN_BASE=~/x-tools/
+
+usage () {
+cat << EOF
+
+Usage: $0 -n <package-name> -p <processor> [-t <toolchain>]
+
+    -n        Go package name pointing to Mender client.
+    -p        Target processor the binary is built for.
+    -t        Specify a toolchain (should be visible in PATH)
+              which will be used to build the client binary.
+
+EOF
+}
+
+while getopts ":n:p:t:" o; do
+  case "${o}" in
+    n)
+      package=${OPTARG}
+      ;;
+    p)
+      _cpu=${OPTARG}
+      ;;
+    t)
+      TOOLCHAIN=${OPTARG}
+      echo "User specified toolchain '$TOOLCHAIN' will be used."
+      ;;
+    :)
+      echo "No argument value for option $OPTARG"
+      ;;
+    "?")
+      echo "Unknown option $OPTARG"
+      exit 1
+      ;;
+    -*)
+      echo "Error: unsupported option $1" >&2
+      exit 1
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+shift $((OPTIND-1))
+
+if [[ -z $package ]] || [[ -z $_cpu ]]; then
+  usage
+  exit 0
+fi
+
+IFS=, read -a cpus <<<"${_cpu}"
+
+package_split=(${package//\// })
+package_name=${package_split[-1]}
+
+for cpu in "${cpus[@]}"
+do
+  GOOS="linux"
+
+  if [ $cpu == "Cortex-A8" ]; then
+    GOARCH="arm"
+    GOARM="7"
+    TARGET=arm-cortex_a8-linux-gnueabihf
+    CGO_CFLAGS="-mtune=cortex-a8 -march=armv7-a+simd+vfpv3+neon -mfloat=hard -mfpu=neon"
+  elif [ $cpu == "Cortex-A53" ]; then
+    GOARCH="arm"
+    GOARM="8"
+    TARGET=armv8-rpi3-linux-gnueabihf
+    CGO_CFLAGS="-mtune=cortex-a53 -mfloat=hard -march=armv8-a+simd+vfpv3+neon -mfpu=neon"
+  else
+    echo "Error: unsupported processor type: $cpu"
+    exit 1
+  fi
+  
+  [ -z $TOOLCHAIN ] && PATH="${PATH}:$TOOLCHAIN_BASE/$TARGET/bin" || TARGET=$TOOLCHAIN
+
+  CC="$TARGET-gcc"
+
+  command -v $CC >/dev/null 2>&1 || { echo >&2 "Expected toolchain '$CC' command not found. Check PATH."; exit 1; }
+
+  printf -v ARCH "%sv%s" $GOARCH $GOARM
+  echo "Building binary for $ARCH architecture..."
+
+  output_name=$package_name'-'$GOOS'-'$GOARCH$GOARM
+
+  go clean $package
+
+  env CGO_ENABLED=1 CC=$CC GOOS=$GOOS GOARCH=$GOARCH CGO_CFLAGS=$CGO_CFLAGS go build -o $output_name $package
+
+  if [ $? -ne 0 ]; then
+    echo 'An error has occurred! Aborting the script execution...'
+    exit 1
+  fi
+  echo "Build successful."
+done
+

--- a/go-executable-build.sh
+++ b/go-executable-build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TOOLCHAIN_BASE=~/x-tools/
+TOOLCHAIN_BASE=${HOME}/x-tools/
 
 usage () {
 cat << EOF


### PR DESCRIPTION
To match the File Attributes found in client binaries built with Yocto
dedicated toolchain can be built. Among others Cortex-A8 and Cortex-A53
are supported.

Purpose of the second script is to cross-compile client binary
using dedicated toolchain for specified architecture/cpu.

Changelog: None

Issues: MEN-1860

Signed-off-by: Adam Podogrocki <a.podogrocki@gmail.com>