### PR TITLE
Setting version of mender client when cross compailed with "go-executable-build.sh"

### DIFF
--- a/go-executable-build.sh
+++ b/go-executable-build.sh
@@ -54,7 +54,7 @@ if [[ -z $package ]] || [[ -z $_cpu ]]; then
 fi
 
 if [[ -z $VERSION ]]; then
-  VERSION = "unknown"
+  VERSION="unknown"
 fi
 
 IFS=, read -a cpus <<<"${_cpu}"

--- a/go-executable-build.sh
+++ b/go-executable-build.sh
@@ -13,7 +13,8 @@ Usage: $0 -n <package-name> -p <processor> [-t <toolchain>]
 EOF
 }
 
-while getopts ":n:p:t:v:" o; do  case "${o}" in
+while getopts ":n:p:t:v:" o; do
+  case "${o}" in
     n)
       package=${OPTARG}
       ;;


### PR DESCRIPTION
Related issue: https://tracker.mender.io/browse/MEN-2576
